### PR TITLE
Add comments to GetClientID

### DIFF
--- a/client.go
+++ b/client.go
@@ -112,6 +112,9 @@ func NewClient(o *ClientOptions) Client {
 	}
 	return c
 }
+// 
+// GetClientID returns the client id
+// The Client id is defined via  ClientOptions and there's no way to access it given a client
 func (c *client) GetClientID() string {
 	return c.options.ClientID
 }


### PR DESCRIPTION
Add GetClientID to client so can we use it for identifying channels based on clients id and communicate based on this id.